### PR TITLE
Don't include dashboard cert info if cert in 'unavailable' status

### DIFF
--- a/lms/templates/design-templates/live-blocks/dashboard-course-listing/_dashboard-course-listing-01.html
+++ b/lms/templates/design-templates/live-blocks/dashboard-course-listing/_dashboard-course-listing-01.html
@@ -298,7 +298,7 @@ from student.helpers import (
       </div>
       % endif
 
-      % if course_overview.may_certify() and cert_status:
+      % if course_overview.may_certify() and cert_status and cert_status.get('status', None) != 'unavailable':
         <%include file='/dashboard/_dashboard_certificate_information.html' args='cert_status=cert_status,course_overview=course_overview, enrollment=enrollment, reverify_link=reverify_link'/>
       % endif
 


### PR DESCRIPTION
Most of our clients use open-ended (no end date) courses.  I've updated edx-platform so that certs start off as 'unavailable' instead of 'processing', for open-ended courses.  This got rid of the nonsense text 'final course details are being wrapped up....' but we were still getting a `<div>` with some styling, just no text.  This change gets rid of all of it by not even including the cert info template for 'unavailable' certs.