### PR TITLE
Don't include certificate info message templ for unavailable cert status

### DIFF
--- a/lms/templates/design-templates/live-blocks/dashboard-course-listing/_dashboard-course-listing-01.html
+++ b/lms/templates/design-templates/live-blocks/dashboard-course-listing/_dashboard-course-listing-01.html
@@ -297,8 +297,10 @@ from student.helpers import (
         </ul>
       </div>
       % endif
-
-      % if course_overview.may_certify() and cert_status:
+      
+      ## TODO: The below change to logic may not work in Ginkgo and onward due to refactoring.  
+      ## Ask Bryan W. (bryanlandia) if you have merge problems.
+      % if course_overview.may_certify() and cert_status and cert_status.get('status', None) != 'unavailable':
         <%include file='/dashboard/_dashboard_certificate_information.html' args='cert_status=cert_status,course_overview=course_overview, enrollment=enrollment, reverify_link=reverify_link'/>
       % endif
 


### PR DESCRIPTION
This duplicates a change made to edx-platform in the base `_dashboard_course_listing.html` template.  Here's that PR (currently merged to `appsembler/ficus/develop`)
https://github.com/appsembler/edx-platform/pull/199/

A previous PR to edx-platform changed the default certificate status for open-ended courses (courses with no end date) to 'unavailable', instead of 'processing'. This got rid of the confusing message 'Final course details are being wrapped up' under the course listing on the dashboard. This goes one step further and makes sure open-ended courses that have not been completed don't produce any kind of cert. message on the dashboard. Basically, this just gets rid of a styled grey <div> with no contents under each course (see screenshot).


![](https://user-images.githubusercontent.com/1289191/35015589-e9dfb348-fac9-11e7-9a3f-c4f74104fb67.png)

I may want to refactor this one for Ginkgo, onward.  There's a comment in the code about that.
