### PR TITLE
apply a fix that fixes the flex-shrink bug

### DIFF
--- a/lms/static/sass/courseware/_courseware-wrapper-01.scss
+++ b/lms/static/sass/courseware/_courseware-wrapper-01.scss
@@ -13,6 +13,8 @@
 
     &__main-content {
       width: 100%;
+      @include flex-shrink(1);
+      min-width: 60%;
     }
 
     &__sidebar {


### PR DESCRIPTION
apply a fix that fixes the flex-shrink bug that causes handouts to overflow in courseware info page. quick fix.