### PR TITLE
Ginkgo: fix course_search_factory 404 error

### DIFF
--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -80,9 +80,12 @@ ${static.get_page_title_breadcrumbs(course_name())}
   <%include file="/mathjax_include.html" args="disable_fast_preview=True"/>
 
   % if settings.FEATURES.get('ENABLE_COURSEWARE_SEARCH'):
-    <%static:require_module module_name="js/search/course/course_search_factory" class_name="CourseSearchFactory">
+    <%static:require_module module_name="course_search/js/course_search_factory" class_name="CourseSearchFactory">
         var courseId = $('.courseware-results').data('courseId');
-        CourseSearchFactory(courseId);
+        CourseSearchFactory({
+            courseId: courseId,
+            searchHeader: $('.search-bar')
+        });
     </%static:require_module>
   % endif
 
@@ -129,7 +132,7 @@ ${HTML(fragment.foot_html())}
 
             % if settings.FEATURES.get('ENABLE_COURSEWARE_SEARCH'):
               <div id="courseware-search-bar" class="search-bar courseware-search-bar" role="search" aria-label="Course">
-                <form>
+                <form class="search-form">
                   <label for="course-search-input" class="sr">${_('Course Search')}</label>
                   <div class="search-field-wrapper">
                     <input id="course-search-input" type="text" class="search-field" placeholder="${_('Course Search')}..."/>


### PR DESCRIPTION
Our staging ginkgo servers in course search is not working after checking i found out they changed course_search_factory.js location to course_search/js/