### PR TITLE
fixes to static_tab.html template

### DIFF
--- a/lms/templates/courseware/static_tab.html
+++ b/lms/templates/courseware/static_tab.html
@@ -11,7 +11,7 @@ from openedx.core.djangolib.markup import HTML
 <%block name="bodyclass">view-in-course view-statictab ${course.css_class or ''}</%block>
 <%namespace name='static' file='/static_content.html'/>
 
-<%block name="headextra">
+<%block name="head_extra">
 <%static:css group='style-course-vendor'/>
 <%static:css group='style-course'/>
 </%block>


### PR DESCRIPTION
In Ginkgo, there's a new variable being used to pull data into custom pages within a course. This change fixes the 500 error that OU was seeing when navigating to an instructor created custom page. e.g.: 

https://lms-staging.ou.customer.appsembler.com/courses/course-v1:appsembler+101+now/92f1129ed9254fa4aed7d81ae72dee49/

@grozdanowski I only made the changes necessary to get rid of the 500 error. It looks like there are a couple of other minor changes between the templates. Please take a look and let me know if any other changes are needed here. Below is the comparison of the template in edx-platform between Ficus and Ginkgo:

https://github.com/appsembler/edx-platform/compare/appsembler/ficus/master...appsembler:appsembler/ginkgo/master

![image](https://user-images.githubusercontent.com/410425/43288957-7c4b24e2-90f7-11e8-8fe4-cad128efea2e.png)
