### PR TITLE
Bugfix for in course static pages

### DIFF
--- a/lms/templates/courseware/static_tab.html
+++ b/lms/templates/courseware/static_tab.html
@@ -13,7 +13,12 @@ from openedx.core.djangolib.markup import HTML
 
 <%block name="head_extra">
 <%static:css group='style-course-vendor'/>
-<%static:css group='style-course'/>
+${HTML(fragment.head_html())}
+</%block>
+
+<%block name="footer_extra">
+<%include file="/mathjax_include.html" args="disable_fast_preview=True"/>
+${HTML(fragment.foot_html())}
 </%block>
 
 <%block name="pagetitle">${tab['name']} | ${course.display_number_with_default | h}</%block>


### PR DESCRIPTION
Remove the import for default LMS course style that gets injected and overrides base sizes.