### PR TITLE
Add a pagetitle for the homepage

### DIFF
--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -7,6 +7,9 @@ from microsite_configuration import microsite
 %>
 
 <%namespace file='/theme-variables.html' import="get_index_content" />
+<%block name="pagetitle">
+  ${_("Home")}
+</%block>
 
 % for element in get_index_content():
   ## this check is AMC-specific


### PR DESCRIPTION
This one's as simple as it gets. Currently the homepages of edX instances we host have a title like:
" | Platform name". That looks sucky on Google. This changes it to "Home | Platform name".
So much improve much wow.