### PR TITLE
Add amirtds' footer logo alt text commits to Ginkgo

### DIFF
--- a/lms/templates/design-templates/footer/_footer-appsembler-01.html
+++ b/lms/templates/design-templates/footer/_footer-appsembler-01.html
@@ -1,4 +1,4 @@
-<%page args="footer_links, footer_logo, footer_copyright_text, display_edx_disclaimer, edx_disclaimer, display_poweredby" />
+<%page args="footer_links, footer_logo, footer_logo_alt_text, footer_copyright_text, display_edx_disclaimer, edx_disclaimer, display_poweredby" />
 <%namespace file='/theme-variables.html' import="get_footer_settings" />
 <%namespace name='static' file='/static_content.html'/>
 <%! from django.utils.translation import ugettext as _ %>
@@ -8,7 +8,7 @@
     <div class="a--footer__main-wrapper">
       <div class="a--footer__main">
         <div class="a--footer__logo">
-          <img src="${footer_logo}" />
+          <img src="${footer_logo}" alt="${footer_logo_alt_text}"/>
         </div>
         <div class="a--footer__nav">
           <p class="a--footer__copyright-text">

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -12,8 +12,9 @@
   display_edx_disclaimer = get_footer_settings().get('display_edx_disclaimer')
   edx_disclaimer = get_footer_settings().get('edx_disclaimer')
   display_poweredby = get_footer_settings().get('display_poweredby')
+  footer_logo_alt_text = get_footer_settings().get('footer_logo_alt_text')
 %>
 
-<%include file = "${get_header_footer_templates()['footer_template']}" args="footer_links = get_footer_menu_items(), footer_logo = footer_logo, footer_copyright_text = footer_copyright_text, display_edx_disclaimer = display_edx_disclaimer, edx_disclaimer = edx_disclaimer, display_poweredby = display_poweredby" />
+<%include file = "${get_header_footer_templates()['footer_template']}" args="footer_links = get_footer_menu_items(), footer_logo = footer_logo, footer_logo_alt_text = footer_logo_alt_text, footer_copyright_text = footer_copyright_text, display_edx_disclaimer = display_edx_disclaimer, edx_disclaimer = edx_disclaimer, display_poweredby = display_poweredby" />
 
 <%include file = '/footer-extra.html' />

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -127,6 +127,7 @@
   <%
     return {
       'footer_logo' : get_brand_logos()['icon_black'], ## leave as is, defined above. Can be changed to something custom if needed.
+      'footer_logo_alt_text' : '',
       'footer_copyright_text' : '2016 Company Name. All rights reserved.',
       'display_edx_disclaimer' : True, ## bool value required
       'edx_disclaimer' : 'edX, Open edX and the edX and Open edX logos are trademarks or registered trademarks of edX Inc.',


### PR DESCRIPTION
See #26 for the related Ficus PR.  Same changes for Ginkgo, plus alt text for Appsembler and Open edX footer logos.