### PR TITLE
Set a max image width of 100% container width on static pages

### DIFF
--- a/lms/static/sass/courseware/_course-static-page.scss
+++ b/lms/static/sass/courseware/_course-static-page.scss
@@ -66,5 +66,6 @@
 
   img {
     max-width: 100%;
+    height: auto;
   }
 }


### PR DESCRIPTION
(some older content expected a containing div with a 100% max-width)

See issue for Open University GInkgo here  https://trello.com/c/hMpzUp9T/3224-ou-ginkgo-upgrade-final-production-upgrade#comment-5b9bf822ebd68045ffc21fbc

