### PR TITLE
remove course catalogue cta on dashboard when catalogue is globally disabled

### DIFF
--- a/lms/templates/design-templates/pages/dashboard/_dashboard-01.html
+++ b/lms/templates/design-templates/pages/dashboard/_dashboard-01.html
@@ -66,8 +66,10 @@ from django.core.urlresolvers import reverse
         % else:
           <div class="a--dashboard-01__main__no-enrollments__container">
             <p>${_("You are not enrolled in any courses yet.")}</p>
-            % if get_dashboard_settings()['promote_course_catalog']:
-              <a class="a--dashboard-01__main__no-enrollments__cta" href="${marketing_link('COURSES')}">${_("Find Courses")}!</a>
+            % if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY') and get_global_settings().get('course-catalogue_enabled', True):
+              % if get_dashboard_settings()['promote_course_catalog']:
+                <a class="a--dashboard-01__main__no-enrollments__cta" href="${marketing_link('COURSES')}">${_("Find Courses")}!</a>
+              % endif
             % endif
           </div>
         % endif


### PR DESCRIPTION
Pretty straightforward - if the course catalogue is globally disabled, then don't display the CTA leading to it on the Dashboard when a user isn't enrolled in any courses.