### PR TITLE
fix displaying of advertised course date on course tiles

### DIFF
--- a/lms/templates/design-templates/live-blocks/single-course/_course-tile-01.html
+++ b/lms/templates/design-templates/live-blocks/single-course/_course-tile-01.html
@@ -29,7 +29,11 @@ from django.utils.translation import ugettext as _
             ${_("Self-Paced")}
           </p>
         % else:
-          <p class="a--course-tile-01__start-date localized_datetime" data-format="shortDate" data-datetime="${course_info['course_start_date']}"></p>
+          % if course_info['course_start_date_display']:
+            <p class="a--course-tile-01__start-date">${course_info['course_start_date_display']}</p>
+          % else:
+            <p class="a--course-tile-01__start-date localized_datetime" data-format="shortDate" data-datetime="${course_info['course_start_date']}"></p>
+          % endif
         % endif
       </div>
     </div>

--- a/lms/templates/design-templates/live-blocks/single-course/_course-tile-02.html
+++ b/lms/templates/design-templates/live-blocks/single-course/_course-tile-02.html
@@ -26,7 +26,11 @@ from django.utils.translation import ugettext as _
           ${_("Self-Paced")}
         </p>
       % else:
-        <p class="a--course-tile-02__start-date localized_datetime" data-format="shortDate" data-datetime="${course_info['course_start_date']}"></p>
+        % if course_info['course_start_date_display']:
+          <p class="a--course-tile-02__start-date">${course_info['course_start_date_display']}</p>
+        % else:
+          <p class="a--course-tile-02__start-date localized_datetime" data-format="shortDate" data-datetime="${course_info['course_start_date']}"></p>
+        % endif
       % endif
     </div>
   </a>

--- a/lms/templates/design-templates/live-blocks/single-course/_course-tile-03.html
+++ b/lms/templates/design-templates/live-blocks/single-course/_course-tile-03.html
@@ -25,7 +25,11 @@ from django.utils.translation import ugettext as _
           ${_("Self-Paced")}
         </p>
       % else:
-        <p class="a--course-tile-03__start-date localized_datetime" data-format="shortDate" data-datetime="${course_info['course_start_date']}"></p>
+        % if course_info['course_start_date_display']:
+          <p class="a--course-tile-03__start-date">${course_info['course_start_date_display']}</p>
+        % else:
+          <p class="a--course-tile-03__start-date localized_datetime" data-format="shortDate" data-datetime="${course_info['course_start_date']}"></p>
+        % endif
       % endif
       <p class="a--course-tile-03__description">${course_info['course_short_description']}</p>
       <a class="a--course-tile-03__more-info" href="${course_info['course_url']}">Learn more...</a>

--- a/lms/templates/translator-templates/_single-course.html
+++ b/lms/templates/translator-templates/_single-course.html
@@ -13,15 +13,7 @@ from courseware.courses import get_course_about_section
 <%def name="get_course_info(course_in)">
   <%
   course = course_in
-  if course.advertised_start is not None:
-    course_start_string = course.advertised_start
-  else:
-    if course.start is not None:
-      course_start_string = course.start.strftime('%Y-%m-%dT%H:%M:%S%z')
-    else:
-      course_start_string = ''
-    endif
-  endif
+  course_start_string = course.advertised_start
   return {
     'course_id' : course.id,
     'course_url' : reverse('about_course', args=[course.id.to_deprecated_string()]),
@@ -29,7 +21,8 @@ from courseware.courses import get_course_about_section
     'course_organization' : course.display_org_with_default,
     'course_code' : course.display_number_with_default,
     'course_title' : course.display_name_with_default,
-    'course_start_date' : course_start_string,
+    'course_start_date' : course.start,
+    'course_start_date_display' : course_start_string,
     'course_end_date' : course.end,
     'course_short_description' : course.short_description,
     'course_number' : course.display_number_with_default


### PR DESCRIPTION
The issue that this fixes is outlined in this card: https://trello.com/c/fUPt0KMj/2520-differences-between-rendering-of-course-catalog-and-course-index-start-dates-and-content

Essentially, when an "advertised course start date" was set in Studio, it would get passed to Moment.js, which would go bananas. The solution?
- course tiles use a singular translator template to get course data
- in that translator template we separate the advertised and the regular course start date into two separate available properties that course tiles can use
- then in course tile we check if the advertised date is set - if it is, we just insert it into the adequate element. If not, we pass the normal course start value to Moment.js, and Moment.js does what it needs to do. Nice and tidy, everything does what it should do.
- "Perfectly balanced, as all things should be." - _Thanos_

If this passes review and gets merged, we need to merge it into ginkgo codebase as well.