### PR TITLE
Fix problem and feedback headings style

### DIFF
--- a/lms/static/sass/courseware/_course-content-01.scss
+++ b/lms/static/sass/courseware/_course-content-01.scss
@@ -606,6 +606,15 @@
         display: block;
       }
 
+      .problem h4, .feedback h3 {
+        @include fontVariantInclude($global-font-base-body);
+        font-size: $font-size-h4;
+        line-height: $line-height-h4;
+        color: $base-text-color;
+        margin: $font-size-h4 0;
+        display: block;
+      }
+
       p {
       	@include fontVariantInclude($global-font-base-body);
       	font-size: $font-size-base-body;


### PR DESCRIPTION
Nothing too fancy, just changing the style of certain titles to match our overall style, per this card: https://trello.com/c/NnYWdnGc/2568-2-appsembler-theme-make-drag-and-drop-component-headings-less-giant-and-not-the-brand-colour

(need to merge this changes into Ginkgo as well)