### PR TITLE
fix an accessibility bug reported by OU

### DIFF
--- a/lms/static/sass/base/_edx-overrides.scss
+++ b/lms/static/sass/base/_edx-overrides.scss
@@ -30,6 +30,7 @@ h2 {
 
 .window-wrap {
 	min-width: 10rem !important;
+	background: none;
 }
 
 .calc-main #calculator_wrapper form .input-wrapper #calculator_input {


### PR DESCRIPTION
An accessibility bug was reported by OU: https://trello.com/c/5zB5acQo/2875-3-ou-ginkgo-theme-grey-background-overridden-accessibility-issue

By the grace of me, a puny yet witty developer, it has been resolved. A line has been added to code. There was much rejoicing.