### PR TITLE
Definitive fix for the grey bg problem in Courseware

### DIFF
--- a/lms/static/sass/base/_edx-overrides.scss
+++ b/lms/static/sass/base/_edx-overrides.scss
@@ -30,7 +30,11 @@ h2 {
 
 .window-wrap {
 	min-width: 10rem !important;
-	background: none;
+	background-color: #f5f5f5;
+
+	.content-wrapper {
+		background: none;
+	}
 }
 
 .calc-main #calculator_wrapper form .input-wrapper #calculator_input {


### PR DESCRIPTION
This PR addresses the issue with the grey bg in Courseware disappearing, covered in this Trello card:
https://trello.com/c/GLjR9rcP/3034-3-ou-lost-grey-surround-from-the-course-outline-page-and-the-custom-pages-while-fixing-the-grey-background-overridden-accessibil