### PR TITLE
Include `theme-google-analytics` in `head-extra`

### DIFF
--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -16,3 +16,5 @@
 % if apple_app_id:
   <meta name="apple-itunes-app" content="app-id=${get_global_settings()['apple_app_id']}">
 % endif
+
+<%include file="/theme-google-analytics.html" />

--- a/lms/templates/theme-google-analytics.html
+++ b/lms/templates/theme-google-analytics.html
@@ -1,2 +1,1 @@
 ## Paste your google analytics script here:
-<script></script>


### PR DESCRIPTION
Because this isn't used anymore automatically by Open edX:

 - https://github.com/edx/edx-platform/blob/6277bd27e68676695f0219bc033ba319e66bd408/themes/README.rst#microsites