### PR TITLE
Increase font size of textarea inputs in content to avoid input zoom on mobile webview

### DIFF
--- a/lms/static/sass/base/_edx-overrides.scss
+++ b/lms/static/sass/base/_edx-overrides.scss
@@ -40,3 +40,9 @@ h2 {
 .xmodule_display.xmodule_HtmlModule img {
 	height: auto;
 }
+
+// make sure textarea input is at least 16px
+// to avoid input zoom on mobile webview
+.a--course-content__main-content textarea {
+	font-size: 1.6rem;
+}


### PR DESCRIPTION
Bringing this over from Ginkgo 