### PR TITLE
Tahoe Hawthorn: Cleaner support for customer CSS files

### DIFF
--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -1,12 +1,17 @@
 ## mako
-
 <%namespace name='static' file='/static_content.html'/>
 <%namespace file='/theme-variables.html' import="get_global_settings" />
-<%! from openedx.core.djangoapps.site_configuration.helpers import get_value %>
+<%! from openedx.core.djangoapps.site_configuration.helpers import get_current_site_configuration, get_value %>
 <%! from django.contrib.staticfiles.templatetags.staticfiles import static %>
 <% style_overrides_file = get_value('css_overrides_file') %>
+
 % if style_overrides_file:
-  <link rel="stylesheet" type="text/css" href="${static(style_overrides_file)}" />
+  ## TODO: `USE_S3_FOR_CUSTOMER_THEMES` should be deprecated. See: github.com/appsembler/edx-platform/issues/341
+  % if settings.USE_S3_FOR_CUSTOMER_THEMES:
+    <link rel="stylesheet" type="text/css" href="${get_current_site_configuration.get_css_url()}" />
+  % else:
+    <link rel="stylesheet" type="text/css" href="${static(style_overrides_file)}" />
+  % endif
 % else:
   <link rel="stylesheet" type="text/css" href="${static('css/main.css')}">
 % endif


### PR DESCRIPTION
`static` used to be used for files that are hosted on S3. With a lot of previous hacks it worked on Ficus.

However, by simplifying the settings in https://github.com/appsembler/edx-platform/pull/337 the `static` file hacks inevitably breaks.

Not calling `static()` and using `get_current_site_configuration.get_css_url()` should solve the problem.