### PR TITLE
Added missing function call

### DIFF
--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -8,7 +8,7 @@
 % if style_overrides_file:
   ## TODO: `USE_S3_FOR_CUSTOMER_THEMES` should be deprecated. See: github.com/appsembler/edx-platform/issues/341
   % if settings.USE_S3_FOR_CUSTOMER_THEMES:
-    <link rel="stylesheet" type="text/css" href="${get_current_site_configuration.get_css_url()}" />
+    <link rel="stylesheet" type="text/css" href="${get_current_site_configuration().get_css_url()}" />
   % else:
     <link rel="stylesheet" type="text/css" href="${static(style_overrides_file)}" />
   % endif


### PR DESCRIPTION
It's not working on staging, unfortunately there's no way to test on devstack currently it other than checking how the code looks.

Related [Sentry issue](https://sentry.io/organizations/appsembler/issues/934651168/?project=145493&query=is%3Aunresolved&statsPeriod=14d&utc=false):

```
AttributeError: 'function' object has no attribute 'get_css_url'
```

I'm merging in an hour or two, even if there's no review. This is breaking Hawthorn staging now.