### PR TITLE
Make the info.html welcome message translatable

### DIFF
--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -67,7 +67,7 @@ from openedx.core.djangolib.markup import HTML, Text
             <div class="a--page-header-main">
               <h3 class="page-title">
                 % if get_global_settings().get('course_info_page_display_course_code', True):
-                  ${_("Welcome to {org}'s {course_name}!").format(org=course.display_org_with_default, course_name=course.display_number_with_default)}
+                  ${_("Welcome to {org}'s {course_title}!").format(org=course.display_org_with_default, course_title=course.display_number_with_default)}
                 % endif
                 <div class="page-subtitle">${course.display_name_with_default}</div>
               </h3>


### PR DESCRIPTION
As seen in [Slack](https://appsembler.slack.com/archives/CAHFFCHPG/p1556297892000100).

The string in the theme differs from the string in the [platform's PO files](https://github.com/appsembler/edx-platform/blob/f8b3a9af9df00f3c776aef56efad671bc83f9e45/conf/locale/fr_CA/LC_MESSAGES/django.po#L17469-L17471), and this pull request fixes it.

> Is there no way to change the course welcome message to another language? French (Canada) is working great, but PSAC can't figure out (and neither can I) how to change this to French.

<kbd><img width="350" src="https://user-images.githubusercontent.com/645156/56847152-2c7f1600-68e0-11e9-9cc3-c8eecc1b7f30.png" /></kbd>