### PR TITLE
bring breadcrumbs to courseware

### DIFF
--- a/lms/static/sass/courseware/_courseware-wrapper-01.scss
+++ b/lms/static/sass/courseware/_courseware-wrapper-01.scss
@@ -165,6 +165,22 @@
   }
 }
 
+.a--courseware-breadcrumbs {
+  padding-top: 2.4rem;
+  padding-bottom: 2.4rem;
+  border-bottom: 0.1rem solid #ddd;
+
+  .breadcrumbs {
+
+    .nav-item {
+
+      a, a:visited {
+        color: $brand-primary-color;
+      }
+    }
+  }
+}
+
 .xblock .xblock h2.unit-title {
   @include primary-font-bold;
   font-size: 2.2rem;

--- a/lms/static/sass/courseware/_top-nav-01.scss
+++ b/lms/static/sass/courseware/_top-nav-01.scss
@@ -1,9 +1,7 @@
 .a--courseware-top-nav {
 
   &__container {
-    border-bottom: 0.1rem solid #ddd;
     padding-top: 1rem;
-    padding-bottom: 1rem;
     margin: $courseware-top-nav-top-margin auto $courseware-top-nav-bottom-margin;
     position: relative;
   }

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -11,6 +11,7 @@ from django.core.urlresolvers import reverse
 from edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled
 from openedx.core.djangolib.markup import HTML
 from openedx.core.djangolib.js_utils import js_escaped_string
+from openedx.features.course_experience import course_home_page_title, COURSE_OUTLINE_PAGE_FLAG
 %>
 <%
   include_special_exams = settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and (course.enable_proctored_exams or course.enable_timed_exams)
@@ -117,6 +118,32 @@ ${HTML(fragment.foot_html())}
 </%block>
 
 <div class="message-banner" aria-live="polite"></div>
+
+<nav aria-label="${_('Course')}" class="a--courseware-breadcrumbs bs-container a--container sr-is-focusable" tabindex="-1">
+  <div class="has-breadcrumbs">
+    <div class="breadcrumbs">
+      % if COURSE_OUTLINE_PAGE_FLAG.is_enabled(course.id):
+        <span class="nav-item nav-item-course">
+          <a href="${course_url}">${course_home_page_title(course)}</a>
+        </span>
+      % endif
+      <span class="icon fa fa-angle-right" aria-hidden="true"></span>
+      % if chapter:
+        <span class="nav-item nav-item-chapter" data-course-position="${course.position}" data-chapter-position="${chapter.position}">
+          <a href="${course_url}#${unicode(chapter.location)}">${chapter.display_name_with_default}</a>
+        </span>
+        <span class="icon fa fa-angle-right" aria-hidden="true"></span>
+      % endif
+      % if section:
+        <span class="nav-item nav-item-section">
+          <a href="${course_url}#${unicode(section.location)}">${section.display_name_with_default}</a>
+        </span>
+        <span class="icon fa fa-angle-right" aria-hidden="true"></span>
+      % endif
+      <span class="nav-item nav-item-sequence">${sequence_title}</span>
+    </div>
+  </div>
+</nav>
 
 % if default_tab:
   <%include file="/courseware/course_navigation.html" />


### PR DESCRIPTION
Basically copy over a missing part of code from default edX template. Then style a bit. Ta-dah.

Per card: https://trello.com/c/qTkUvt2A/4055-hawthorn-testing-lms-no-clickable-breadcrumbs