### PR TITLE
Patch: Show the hidden fields in ORA2 instructor dashboard

### DIFF
--- a/lms/static/sass/pages/_instructor-dashboard.scss
+++ b/lms/static/sass/pages/_instructor-dashboard.scss
@@ -21,3 +21,16 @@
     }
   }
 }
+
+.open-response-assessment-block {
+  .backgrid {
+    // Patch for the ORA2 to show hidden fields
+    .parent_name {
+      width: 180px;
+    }
+
+    .name {
+      width: 230px;
+    }
+  }
+}


### PR DESCRIPTION
For whatever reason, those fields are hidden. I don't think forking ORA2 will solve the issue.

**Unit Name** and **Assessment** were hidden.


### Before
![image](https://user-images.githubusercontent.com/645156/57572830-c68aa680-7428-11e9-9134-7723688ed831.png)



### After
![image](https://user-images.githubusercontent.com/645156/57572824-9e9b4300-7428-11e9-94d3-a531fe4f8ebd.png)
