### PR TITLE
make small cosmetic fixes to discussions view header

### DIFF
--- a/lms/static/sass/discussion/_appsembler-discussion-overrides.scss
+++ b/lms/static/sass/discussion/_appsembler-discussion-overrides.scss
@@ -289,3 +289,34 @@
     }
   }
 }
+
+.discussion .page-header {
+
+  .page-header-main {
+    display: flex;
+
+    .breadcrumbs {
+      margin-top: 0;
+      margin-bottom: 0 !important;
+
+      .nav-item {
+
+        .btn-link.all-topics {
+          height: 41px;
+        }
+      }
+    }
+  }
+
+  .page-header-secondary {
+
+    .forum-actions {
+
+      .btn {
+        height: 100%;
+        padding-left: 1.5rem;
+        padding-right: 1.5rem;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Screenshot shows fixed (header buttons height):

<img width="1339" alt="Screenshot 2019-05-13 at 16 30 07" src="https://user-images.githubusercontent.com/10602234/57629711-89472580-759c-11e9-89f7-3bbf5c51d88d.png">
