### PR TITLE
fix consistency in course card 3 underscore template

### DIFF
--- a/lms/templates/discovery/_course-tile-03.underscore
+++ b/lms/templates/discovery/_course-tile-03.underscore
@@ -8,14 +8,19 @@
         <p class="a--course-tile-03__start-date">
           <% if ([gettext("Self-paced"), gettext("Self-Paced"), gettext("self-paced"), gettext("SELF-PACED")].indexOf(gettext(start)) !== -1) { %>
             <%= gettext(start) %>
-          <% } else { %>
+          <% } else if (Date.parse(start)) { %>
             <%= interpolate(
               gettext("Starts: %(start_date)s"),
               { start_date: start }, true
             ) %>
+          <% } else { %>
+            <%= interpolate(
+              gettext("%(start_date)s"),
+              { start_date: start }, true
+            ) %>
           <% } %>
         </p>
-      <p class="a--course-tile-03__description"><%= content.overview.substr(0,220) %>...</p>
+      <p class="a--course-tile-03__description"><%= content.short_description %></p>
       <a class="a--course-tile-03__more-info" href="/courses/<%- course %>/about">Learn more...</a>
     </div>
   </div>


### PR DESCRIPTION
This fix to the course card 03 underscore template addresses issues that were reported to us by Akamai, and flagged as high priority because it is effectively blocking them.

Changes are:
- the card now displays course short description, not the course overview. This is to be consistent to be with the standard Mako card template that's being displayed on the Index page. It is also plain and simple - sane.
- the card checks if the "starts" text is self paced. That's a previously already established functionality. Now after that check we check if the field contains a valid date. If so - we display the "Starts: " string. If not, then we just display the var content, since it's the case of customer using it to have their custom text.

I have no ways to actually locally test this properly (aside from testing with hardcoded values in template), as search indexing doesn't work. Let's test this on Staging.