### PR TITLE
fix that annoying “| “ artefact in index page title

### DIFF
--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -8,6 +8,12 @@ from microsite_configuration import microsite
 
 <%namespace file='/theme-variables.html' import="get_index_content" />
 
+<%block name="title">
+  <title data-base-title="${static.get_page_title_breadcrumbs()}">
+    ${static.get_page_title_breadcrumbs()}
+  </title>
+</%block>
+
 % for element in get_index_content():
   ## this check is AMC-specific
   % if (element['element-type'].startswith('layout')):


### PR DESCRIPTION
The way this is set up in `main.html` with all the lovely "quirks" of Mako for some reason passes value of [""] as `crumbs` argument to the function that returns the final formatted title. In order to override this (since it actually works fine on all other pages) we just override the title block in index template to not include `self.pagetitle()` as argument, therefore eliminating this issue.