### PR TITLE
check if course start is a custom string then display directly

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -190,7 +190,9 @@ from six import string_types
 
   if course.advertised_start is not None:
     course_start_string = course.advertised_start
+    course_about_vars['course_start_is_custom'] = True
   else:
+    course_about_vars['course_start_is_custom'] = False
     if course.start is not None:
       course_start_string = course.start.strftime('%Y-%m-%dT%H:%M:%S%z')
     else:

--- a/lms/templates/design-templates/pages/course-about/_course-about-01.html
+++ b/lms/templates/design-templates/pages/course-about/_course-about-01.html
@@ -118,7 +118,15 @@ from django.utils.translation import ugettext as _
       <li><i class="fa fa-info-circle"></i><p>${_("Course Number")}</p><span>${course_vars['course_number']}</span></li>
       % if not course_vars['self_paced']:
         % if course_vars['course_display_start_date']:
-          <li><i class="fa fa-calendar"></i><p>${_("Classes Start")}</p><span class="localized_datetime" data-format="shortDate" data-datetime="${course_vars['course_start_date']}"></span></li>
+          <li>
+            <i class="fa fa-calendar"></i>
+            <p>${_("Classes Start")}</p>
+            % if course_vars['course_start_is_custom']:
+              <span>${course_vars['course_start_date']}</span>
+            % else:
+              <span class="localized_datetime" data-format="shortDate" data-datetime="${course_vars['course_start_date']}"></span>
+            % endif
+          </li>
         % endif
         % if course_vars['course_end_date']:
           <li><i class="fa fa-calendar"></i><p>${_("Classes End")}</p><span class="localized_datetime" data-format="shortDate" data-datetime="${course_vars['course_end_date']}"></span></li>


### PR DESCRIPTION
On course about page, when we display the course start date we actually pass it to a JS function that actually outputs the proper formatted string for the date.

Issue happens when an Advertised course date string is set. The JS goes bananas. This PR fixes that - we check if the date is customised, and if it is we no longer pass it to JS but display directly.