### PR TITLE
fix handling of special chars in enrolment buttons

### DIFF
--- a/lms/templates/design-templates/pages/course-about/_course-about-01.html
+++ b/lms/templates/design-templates/pages/course-about/_course-about-01.html
@@ -15,8 +15,8 @@ from django.utils.translation import ugettext as _
   courseware_button_course_full_text = template_settings.get('courseware_button_course_full_text', _("Course is full"))
   courseware_button_invitation_only_text = template_settings.get('courseware_button_invitation_only_text', _("Enrollment in this course is by invitation only"))
   courseware_button_enrollment_closed_text = template_settings.get('courseware_button_enrollment_closed_text', _("Enrollment is Closed"))
-  courseware_button_add_to_cart_text = "{text} {price}".format(text=template_settings.get('courseware_button_add_to_cart_text', _("Add to Cart / Price: ")), price=course_vars['course_price'])
-  courseware_button_enroll_text = "{text} {price}".format(text=template_settings.get('courseware_button_add_to_cart_text', _("Enroll in ")), price=course_vars['course_name'])
+  courseware_button_add_to_cart_text = u"{text} {price}".format(text=template_settings.get('courseware_button_add_to_cart_text', _("Add to Cart / Price: ")), price=course_vars['course_price'])
+  courseware_button_enroll_text = u"{text} {name}".format(text=template_settings.get('courseware_button_add_to_cart_text', _("Enroll in ")), name=course_vars['course_name'])
   view_in_studio_button_text = template_settings.get('view_in_studio_button_text', _("View About Page in studio"))
 %>
 


### PR DESCRIPTION
Errors were thrown upon using Japanese characters on the button. HelpScout was alarmed. Engineers convened. Problem fixed. Thou shall not oppress these kind people, Python!