### PR TITLE
add space between “welcome” and users name in header

### DIFF
--- a/lms/static/sass/header/_header-appsembler-01.scss
+++ b/lms/static/sass/header/_header-appsembler-01.scss
@@ -229,6 +229,11 @@
           margin-right: 1.5rem;
         }
 
+        span {
+          display: inline-block;
+          margin-left: 0.5rem;
+        }
+
         @media(max-width: $screen-sm-max) {
           display: none;
         }

--- a/lms/static/sass/header/_header-appsembler-02.scss
+++ b/lms/static/sass/header/_header-appsembler-02.scss
@@ -234,6 +234,11 @@
           margin-right: 1.5rem;
         }
 
+        span {
+          display: inline-block;
+          margin-left: 0.5rem;
+        }
+
         @media(max-width: $screen-sm-max) {
           display: none;
         }


### PR DESCRIPTION
Report from customer: "As reported by Optum, the name and welcome message get smushed together."

This simple fix adds that space.