### PR TITLE
make image height fixed and do some styling of the tile

### DIFF
--- a/lms/static/sass/live-blocks/single-course/_course-tile-03.scss
+++ b/lms/static/sass/live-blocks/single-course/_course-tile-03.scss
@@ -4,9 +4,9 @@
   max-width: 92rem;
   width: 100%;
   @include transition(all 0.3s ease-in-out);
-  border: 0.1rem solid #dedede;
   text-align: left;
   position: relative;
+  background-color: #fff;
 
   &:hover, &:focus {
     -webkit-box-shadow: 0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22);
@@ -17,13 +17,16 @@
 
   @media(min-width: $screen-sm-min) {
     @include display(flex);
+    @include align-items(center);
     margin: 1.5rem 0;
 
     &__image {
       display: block;
       width: 26rem;
       @include flex-shrink(0);
-      margin-right: 1.5rem;
+      height: 18rem;
+      margin-left: 2rem;
+      margin-right: 1rem;
     }
   }
 
@@ -33,8 +36,7 @@
   }
 
   &__info-container {
-    padding: 3rem 1.5rem;
-    background-color: #fff;
+    padding: 3rem 2rem;
     width: 100%;
   }
 


### PR DESCRIPTION
This PR addresses an issue raised by Matthew in [this Trello card](https://trello.com/c/k3SJcOI7/4363-4-theme-course-tile-type-03-displays-images-at-a-different-aspect-ratio-to-the-dashboard-page).

Screenshots of updated look:
![Screenshot 2019-08-09 at 13 20 06](https://user-images.githubusercontent.com/10602234/62779955-dc097e00-bab4-11e9-8a5a-e62300814851.png)
![Screenshot 2019-08-09 at 13 19 46](https://user-images.githubusercontent.com/10602234/62779956-dc097e00-bab4-11e9-83de-c38e9cb9ef65.png)
