### PR TITLE
fix discussion filters layout by styling

### DIFF
--- a/lms/static/sass/discussion/_appsembler-discussion-overrides.scss
+++ b/lms/static/sass/discussion/_appsembler-discussion-overrides.scss
@@ -9,6 +9,22 @@
 
   .forum-nav-refine-bar {
     @include display(flex);
+    @include flex-wrap(wrap);
+
+    label {
+      width: 100%;
+      text-align: left;
+      padding: 0.5rem 0;
+      border-bottom: 0.1rem solid #ccc;
+
+      &:last-of-type {
+        border-bottom: none;
+      }
+
+      select {
+        width: 100%;
+      }
+    }
 
     .forum-nav-filter-main, .forum-nav-sort {
       flex: 1 1 100%;


### PR DESCRIPTION
This PR addresses an issue outlined in [this Trello card](https://trello.com/c/hB6v6gcj/4174-3-teksystems-discussion-layout-issue).

Some styling fixed it and made way better. Screenshot below:

![Screenshot 2019-08-09 at 15 03 48](https://user-images.githubusercontent.com/10602234/62780914-0d834900-bab7-11e9-9a2a-80ff124c4319.png)
