### PR TITLE
Style account removal section in account settings

### DIFF
--- a/lms/static/sass/pages/_account-settings.scss
+++ b/lms/static/sass/pages/_account-settings.scss
@@ -79,5 +79,85 @@
 				}
 			}
 		}
+
+		.account-deletion-details {
+			padding-bottom: 5rem;
+
+			.btn-outline-primary.paragon__btn {
+				font-size: 1.6rem;
+				padding: 1.2rem 1.6rem;
+				min-width: 30%;
+				border: 0.1rem solid $brand-primary-color;
+				background: transparent;
+				color: $brand-primary-color;
+
+				&:hover, &:focus {
+					background: $brand-primary-color;
+					color: pick-visible-color($brand-primary-color, #000, #fff);
+					cursor: pointer;
+				}
+			}
+
+			.delete-confirmation-wrapper {
+
+				.paragon__modal-header {
+					padding: 1rem 2rem 2rem;
+				}
+
+				.paragon__modal-body {
+					padding: 2rem;
+				}
+
+				.paragon__alert {
+					padding: 2rem;
+				}
+
+				.next-steps {
+					margin-top: 2rem;
+					margin-bottom: 2rem;
+				}
+
+				.modal-alert .alert-content .alert-title {
+					font-size: 1.6rem;
+					margin-bottom: 2rem;
+				}
+
+				.paragon__modal-footer {
+					padding: 2rem;
+
+					.paragon__btn {
+						font-size: 1.6rem;
+						padding: 1.2rem 1.6rem;
+						line-height: 140%;
+						border: 0.1rem solid $brand-primary-color;
+						color: pick-visible-color($brand-primary-color, #000, #fff);
+						background: $brand-primary-color;
+						margin-left: 1rem;
+						box-shadow: none;
+
+						&:hover, &:focus {
+							background: darken($brand-primary-color, 15%);
+							color: pick-visible-color(darken($brand-primary-color, 15%), #000, #fff);
+							cursor: pointer;
+							box-shadow: none;
+						}
+
+						&.paragon__btn-outline-primary {
+							background: transparent;
+							color: $brand-primary-color;
+
+							&:hover, &:focus {
+								background: $brand-primary-color;
+								color: pick-visible-color($brand-primary-color, #000, #fff);
+							}
+						}
+
+						&:disabled {
+							border-color:rgb(164, 166, 168);
+						}
+					}
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
This PR addresses missing styling of account removal in student account settings. New state is seen from the gif:

![accountdeletionstyle](https://user-images.githubusercontent.com/10602234/64633614-d4166400-d3fb-11e9-97f1-e200f2900352.gif)
