### PR TITLE
Fix deletion success modal styles

### DIFF
--- a/lms/static/sass/pages/_account-settings.scss
+++ b/lms/static/sass/pages/_account-settings.scss
@@ -98,7 +98,7 @@
 				}
 			}
 
-			.delete-confirmation-wrapper {
+			.delete-confirmation-wrapper, .delete-success-wrapper {
 
 				.paragon__modal-header {
 					padding: 1rem 2rem 2rem;


### PR DESCRIPTION
This fixes the `delete-success-wrapper` action button and styles to match the `delete-confirmation-wrapper` that was fixed earlier in #88 

<img width="536" alt="Screen Shot 2019-10-02 at 6 21 17 PM" src="https://user-images.githubusercontent.com/11036472/66092598-6fa17d00-e541-11e9-9a8f-882ad3fd2a4e.png">
