### PR TITLE
Fix dashboard search in Hawthorn

### DIFF
--- a/lms/templates/design-templates/pages/dashboard/_dashboard-01.html
+++ b/lms/templates/design-templates/pages/dashboard/_dashboard-01.html
@@ -123,7 +123,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
         % endif
       </div>
       % if get_dashboard_settings()['dashboard_search_enabled']:
-        <div class="a--dashboard-01__main__search-results" id="dashboard-search-results">
+        <div class="a--dashboard-01__main__search-results search-results" id="dashboard-search-results">
         </div>
       % endif
     </div>


### PR DESCRIPTION
Course search in Dashboard doesn't work in Hawthorn. Upon investigating, I have found the cause of the issue is a change in JS made in platform - [commit here](https://github.com/appsembler/edx-platform/commit/c0007a11f38481b3af869bd8c368ec64e180ee9e#diff-7afba099b44c56137a60675dd5b10ae0).
Essentially, the way JS determines where to inject results has changed so results don't end up anywhere. A change has been made that should alleviate this issue, however we cannot test locally (in devstack currently the search functionality is disabled). Therefore we need to test this out on Staging.