### PR TITLE
Hide the confusing Language Proficiencies field

### DIFF
--- a/lms/static/sass/pages/_account-settings.scss
+++ b/lms/static/sass/pages/_account-settings.scss
@@ -78,6 +78,13 @@
 					}
 				}
 			}
+
+			.u-field-language_proficiencies {
+				// Hide it so student can chose the correct "Language" field.
+				// Because this "Preferred Language" aka "Language Proficiencies" is a
+				// very confusing field that we don't use. Mainly edX have it for data-collection purposes.
+				display: none;
+			}
 		}
 
 		.account-deletion-details {


### PR DESCRIPTION
Hide it so student can chose the correct "Language" field.
Because this "Preferred Language" aka "Language Proficiencies" is a
very confusing field that we don't use. Mainly edX have it for data-collection purposes.

### Screenshot
<kbd>![image](https://user-images.githubusercontent.com/645156/68109285-38850980-fefb-11e9-9b10-d9895108d289.png)</kbd>
