### PR TITLE
Have the hamburger menu scroll when items don’t fit

### DIFF
--- a/lms/static/sass/header/_header-appsembler-01.scss
+++ b/lms/static/sass/header/_header-appsembler-01.scss
@@ -419,7 +419,6 @@
     padding-top: 10rem;
     padding-bottom: 50rem;
     height: 100vh;
-    overflow-y: auto;
     left: 0;
     top: 0;
     background-color: $slideout-menu-background-color;
@@ -431,6 +430,7 @@
     -webkit-transition-timing-function: cubic-bezier(0.7,0,0.3,1);
     transition-timing-function: cubic-bezier(0.7,0,0.3,1);
     overflow: hidden;
+    overflow-y: auto;
 
     li {
       display: block;

--- a/lms/static/sass/header/_header-appsembler-02.scss
+++ b/lms/static/sass/header/_header-appsembler-02.scss
@@ -434,7 +434,6 @@
     padding-top: 10rem;
     padding-bottom: 50rem;
     height: 100vh;
-    overflow-y: auto;
     right: 0;
     top: 0;
     background-color: $slideout-menu-background-color;
@@ -446,6 +445,7 @@
     -webkit-transition-timing-function: cubic-bezier(0.7,0,0.3,1);
     transition-timing-function: cubic-bezier(0.7,0,0.3,1);
     overflow: hidden;
+    overflow-y: auto;
 
     li {
       display: block;

--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -315,6 +315,7 @@ ul.a--slide-menu__container {
   -webkit-transition-timing-function: cubic-bezier(0.7,0,0.3,1);
   transition-timing-function: cubic-bezier(0.7,0,0.3,1);
   overflow: hidden;
+  overflow-y: auto;
 
   li {
     display: block;


### PR DESCRIPTION
PEPFAR was reporting their users cannot see the log out option in the hamburger menu when on small screens. They have a bit of items there and because of a bug in frontend the menu doesn't scroll properly. Now it does. LOOK HOW IT DOES!

Note: we need to rebuild the SASS for all Tahoe customers upon deploying this to Production.

![nowmenuworks](https://user-images.githubusercontent.com/10602234/68425560-a2750b80-01a6-11ea-9cb6-1e376d57f310.gif)