### PR TITLE
Fix course tile 02 in course catalogue

### DIFF
--- a/lms/templates/discovery/_course-tile-02.underscore
+++ b/lms/templates/discovery/_course-tile-02.underscore
@@ -5,17 +5,16 @@
     <div class="a--course-tile-02__info">
       <p class="a--course-tile-02__code"><%= content.number %></p>
       <p class="a--course-tile-02__title"><%= content.display_name %></p>
-      <p class="a--course-tile-02__organization"><%= display_org_with_default %></p>
-        <p class="a--course-tile-02__start-date">
-            <% if ([gettext("Self-paced"), gettext("Self-Paced"), gettext("self-paced"), gettext("SELF-PACED")].indexOf(gettext(start)) !== -1) { %>
-              <%= gettext(start) %>
-            <% } else { %>
-              <%= interpolate(
-                gettext("Starts: %(start_date)s"),
-                { start_date: start }, true
-              ) %>
-            <% } %>
-          </p>
+      <p class="a--course-tile-02__start-date">
+          <% if ([gettext("Self-paced"), gettext("Self-Paced"), gettext("self-paced"), gettext("SELF-PACED")].indexOf(gettext(start)) !== -1) { %>
+            <%= gettext(start) %>
+          <% } else { %>
+            <%= interpolate(
+              gettext("Starts: %(start_date)s"),
+              { start_date: start }, true
+            ) %>
+          <% } %>
+        </p>
     </div>
   </a>
 </article>


### PR DESCRIPTION
Per [the JIRA issue](https://appsembler.atlassian.net/browse/RED-233), if course catalog search is enabled and the Course tile 02 option is selected for display - no courses appear. The problem was that that type of course card still had the old reference to Organisation (which doesn't make sense for us since it's always the same one). That reference was removed from the object so JS couldn't fetch it. So we remove it.