### PR TITLE
Improve positioning and visual style for staff debug btns

### DIFF
--- a/lms/static/sass/courseware/_courseware-wrapper-01.scss
+++ b/lms/static/sass/courseware/_courseware-wrapper-01.scss
@@ -54,11 +54,20 @@
     }
 
     .wrap-instructor-info, .wrap-instructor-info.studio-view {
-      margin: 3rem 0 -5rem;
-      margin: 3rem 0 0;
-      display: block;
+      @include display(flex);
+      @include flex-wrap(wrap);
+      @include align-items(center);
+      @include justify-content(flex-end);
       top: 0;
+      margin: 0 0 5rem;
+      padding: 2rem 0;
+      border-bottom: 1px dashed #eee;
       @include primary-font;
+
+      .instructor-info-action {
+        display: inline-block;
+        margin-left: 0.5rem;
+      }
     }
 
     h1 {


### PR DESCRIPTION
This fixes positioning of staff debug buttons in course content. As per JIRA issue, "The instructor info wrapper has a massive margin on the top, which causes it to drop into the next component. This leads to confusion around which component the button is for.".

So we made it better. Even some dashed lines to make it clearer. Wow. Screenshot below.

![Screenshot 2019-12-09 at 12 09 03](https://user-images.githubusercontent.com/10602234/70431471-6a026f00-1a7d-11ea-894b-78b667f6c136.png)
