### PR TITLE
increase staff debug modal width in LMS

### DIFF
--- a/lms/static/sass/courseware/_course-content-01.scss
+++ b/lms/static/sass/courseware/_course-content-01.scss
@@ -721,3 +721,12 @@
     }
   }
 }
+
+.modal.staff-modal {
+  width: 980px;
+  max-width: 100%;
+
+  .inner-wrapper {
+    padding: 2.5rem;
+  }
+}


### PR DESCRIPTION
It was weird and narrow and just impractical. Now it's better. Screenshot below.

<img width="1680" alt="Screenshot 2019-12-10 at 14 17 05" src="https://user-images.githubusercontent.com/10602234/70532726-e6698080-1b57-11ea-88f5-1744081d6290.png">
