### PR TITLE
keep the correct ratios of columns

### DIFF
--- a/lms/static/sass/page-builder/layouts/_layouts-base.scss
+++ b/lms/static/sass/page-builder/layouts/_layouts-base.scss
@@ -12,8 +12,8 @@
 
     @media (min-width: $screen-sm-min) {
       padding: 1.5rem;
-      flex: 1 1 1rem;
-      -webkit-flex: 1 1 1rem;
+      flex-grow: 1;
+      flex-shrink: 1;
     }
   }
 }


### PR DESCRIPTION
The ratios of 2:1 and 1:2 column layouts weren't being respected when rendering the page. A flex setting was the cause.

A 2:1 layout before the fix:

<img width="460" alt="Screenshot 2020-06-01 at 14 51 41" src="https://user-images.githubusercontent.com/10602234/83411029-c1bfd880-a417-11ea-9528-bf8b337e547b.png">

A 2:1 layout after the fix:

<img width="460" alt="Screenshot 2020-06-01 at 14 51 50" src="https://user-images.githubusercontent.com/10602234/83411044-c7b5b980-a417-11ea-9c5b-5cdc16a4da29.png">