### PR TITLE
If set to only-SSO login - enable registration using SSO

### DIFF
--- a/lms/templates/student_account/a--register-disabled.underscore
+++ b/lms/templates/student_account/a--register-disabled.underscore
@@ -1,3 +1,47 @@
-<div class="a--register-disabled">
-  <h1 class="a--register-disabled">Self-registration for this site is disabled.</h1>
+<div class="js-form-feedback" aria-live="assertive" tabindex="-1">
 </div>
+
+<% if (!context.syncLearnerProfileData) { %>
+	<div class="toggle-form">
+		<span class="text"><%- edx.StringUtils.interpolate(gettext('Already have an {platformName} account?'), {platformName: context.platformName }) %></span>
+		<a href="#login" class="form-toggle" data-type="login"><%- gettext("Sign in.") %></a>
+	</div>
+<% } %>
+
+<form id="register" class="register-form" autocomplete="off" tabindex="-1" method="POST">
+
+    <% if (!context.currentProvider) { %>
+        <% if (context.providers.length > 0 || context.hasSecondaryProviders) { %>
+            <div class="login-providers">
+                <div class="section-title lines">
+                    <h3>
+                        <span class="text"><%- gettext("Create an account using") %></span>
+                    </h3>
+                </div>
+                <%
+                _.each( context.providers, function( provider) {
+                    if ( provider.registerUrl ) { %>
+                        <button type="button" class="button button-primary button-<%- provider.id %> login-provider register-<%- provider.id %>" data-provider-url="<%- provider.registerUrl %>">
+                            <div class="icon <% if ( provider.iconClass ) { %>fa <%- provider.iconClass %><% } %>" aria-hidden="true">
+                                <% if ( provider.iconImage ) { %>
+                                    <img class="icon-image" src="<%- provider.iconImage %>" alt="<%- provider.name %> icon" />
+                                <% } %>
+                            </div>
+                            <span aria-hidden="true"><%- provider.name %></span>
+                            <span class="sr"><%- _.sprintf( gettext("Create account using %(providerName)s."), {providerName: provider.name} ) %></span>
+                        </button>
+                <%  }
+                }); %>
+
+                <% if ( context.hasSecondaryProviders ) { %>
+                    <button type="button" class="button-secondary-login form-toggle" data-type="institution_login">
+                        <%- gettext("Use my institution/campus credentials") %>
+                    </button>
+                <% } %>
+            </div>
+        <% } %>
+    <% } else if (context.autoRegisterWelcomeMessage) { %>
+        <span class="auto-register-message"><%- context.autoRegisterWelcomeMessage %></span>
+    <% } %>
+
+</form>


### PR DESCRIPTION
Here's the context as reported from a customer:

_They pointed that when they hide the login fields and registration form, the behave different, while the login form shows only the SSO login button which is correct, the registration form only shows a message saying self-registration is disabled on the site. Despite this is by design, it uncovered a design problem, since they want the SSO button to be shown in the registration form as well._

Basically, we didn't account for the situation where the customer wants to use exclusively SSO for student accounts, as essentially we don't give the option for registering against the SSO provider. Now that should be ammended.

**Note: This needs to be thoroughly tested in Staging!**