### PR TITLE
set a fixed ratio to images in course catalogue

### DIFF
--- a/lms/static/sass/live-blocks/single-course/_course-tile-01.scss
+++ b/lms/static/sass/live-blocks/single-course/_course-tile-01.scss
@@ -43,7 +43,8 @@
 
   &__image {
     width: 100%;
-    height: 18rem;
+    height: auto;
+    padding-bottom: 66%;
     background-size: cover;
     background-position: center center;
     @include flex-grow(0);


### PR DESCRIPTION
As per an issue submitted by Matthew, the way how course images in course cards act in a responsive way is not good. This PR introduces a fixed aspect ratio for them, while keeping them responsive.

Which is nice.