### PR TITLE
Override how the LTI consumer xblock title looks

### DIFF
--- a/lms/static/sass/base/_edx-overrides.scss
+++ b/lms/static/sass/base/_edx-overrides.scss
@@ -100,3 +100,13 @@ a:visited:not(.btn):focus {
 .wrapper-account-settings .account-settings-container .wrapper-header .account-nav #orders-tab {
 	display: none;
 }
+
+
+.xblock-student_view-lti_consumer h2 {
+	@include fontVariantInclude($global-font-h4);
+	font-size: $font-size-h4;
+	line-height: $line-height-h4;
+	color: $base-text-color;
+	margin: $font-size-h4 0;
+	display: block;
+}


### PR DESCRIPTION
In the respective xblock the heading is H2, yet it should be H3. Since we don't want to fork because of that, we'll (at least for now) just override the style of it so it looks like it is H3. Sneaky sneaky.