### PR TITLE
Change the behaviour of registration form hiding for SSO purposes

### DIFF
--- a/lms/static/sass/pages/_combined-login-register.scss
+++ b/lms/static/sass/pages/_combined-login-register.scss
@@ -273,4 +273,11 @@
       }
     }
   }
+
+  .register-form.register-fields-disabled {
+    
+    .required-fields, .checkbox-optional_fields_toggle, .optional-fields, .register-button, .view-disabled {
+      display: none;
+    }
+  }
 }

--- a/lms/templates/student_account/a--register-disabled.underscore
+++ b/lms/templates/student_account/a--register-disabled.underscore
@@ -8,7 +8,7 @@
 	</div>
 <% } %>
 
-<form id="register" class="register-form" autocomplete="off" tabindex="-1" method="POST">
+<form id="register" class="register-form register-fields-disabled" autocomplete="off" tabindex="-1" method="POST">
 
     <% if (!context.currentProvider) { %>
         <% if (context.providers.length > 0 || context.hasSecondaryProviders) { %>
@@ -39,9 +39,31 @@
                     </button>
                 <% } %>
             </div>
+            <div class="section-title lines">
+                <h3>
+                    <span class="text"><%- gettext("or create a new one here") %></span>
+                </h3>
+            </div>
+        <% } else { %>
+            <h2 class="view-disabled"><%- gettext('Create an Account')%></h2>
         <% } %>
     <% } else if (context.autoRegisterWelcomeMessage) { %>
         <span class="auto-register-message"><%- context.autoRegisterWelcomeMessage %></span>
     <% } %>
 
+    <%= context.fields /* xss-lint: disable=underscore-not-escaped */ %>
+
+    <div class="form-field checkbox-optional_fields_toggle">
+        <input type="checkbox" id="toggle_optional_fields" class="input-block checkbox"">
+        <label for="toggle_optional_fields">
+            <span class="label-text">
+                <%- gettext("Support education research by providing additional information") %>
+            </span>
+        </label>
+    </div>
+
+
+    <button type="submit" class="action action-primary action-update js-register register-button">
+    	<% if ( context.registerFormSubmitButtonText ) { %><%- context.registerFormSubmitButtonText %><% } else { %><%- gettext("Create Account") %><% } %>
+    </button>
 </form>


### PR DESCRIPTION
As per following ticket: https://appsembler.atlassian.net/browse/RED-1693

In short: we now no longer _omit fields_, but rather still render them but then hide them. That way SSO should still be able to autofill.