### PR TITLE
Add tos to hidden class part of SSO registration form fixes

### DIFF
--- a/lms/static/sass/pages/_combined-login-register.scss
+++ b/lms/static/sass/pages/_combined-login-register.scss
@@ -275,8 +275,8 @@
   }
 
   .register-form.register-fields-disabled {
-    
-    .required-fields, .checkbox-optional_fields_toggle, .optional-fields, .register-button, .view-disabled {
+
+    .required-fields, .checkbox-optional_fields_toggle, .optional-fields, .register-button, .view-disabled, .checkbox-terms_of_service {
       display: none;
     }
   }


### PR DESCRIPTION
@grozdanowski This is a follow up of: https://github.com/appsembler/edx-theme-codebase/pull/119

We're still displaying the terms of service when we hide the form.