### PR TITLE
Don't hide Progress page cert info if course not passed

### DIFF
--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -61,7 +61,7 @@ from django.utils.http import urlquote_plus
       %if certificate_data:
       <div class="wrapper-msg wrapper-auto-cert">
           <div id="errors-info" class="errors-info"></div>
-          %if passed:
+          %if passed or certificate_data.cert_status == CertificateStatuses.downloadable:
           <div class="auto-cert-message" id="course-success">
               <div class="has-actions">
                   <% post_url = reverse('generate_user_cert', args=[unicode(course.id)]) %>


### PR DESCRIPTION
fixes issue where students given Exception Cert cannot see certificate