### PR TITLE
(Urgent) Workaround not found gettext files in Japanese

### DIFF
--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -78,6 +78,7 @@ from pipeline_mako import render_require_js_path_overrides
     </script>
   % endif
   <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
+  <%static:optional_include_mako file="gettext_staticfiles_fixes/patch_missing_gettext_hack.html" />
   <script type="text/javascript" src="${static.url(ie11_fix_path)}"></script>
 
   <link rel="icon" type="image/x-icon" href="${get_brand_favicon()['brand_favicon']}" />


### PR DESCRIPTION
RED-1698: Depends on https://github.com/appsembler/edx-theme-customers/pull/141


### Please prioritize quickly but review carefully

A customer is launching their site on Monday February 15th, 2021 and there's a bug that's blocking them. We cannot let this wait too much and ideally deploy on Monday. However, I don't want to skip proper review and make a bigger problem.

### This is a stopgap, where's the full fix?

The root cause fix should be in https://github.com/appsembler/configuration/pull/348 but I don't want to wait for another round (usually 1-2 weeks) of customer testing and debugging so I'm fixing it twice