### PR TITLE
remove reference to TrackEcommerceEvents

### DIFF
--- a/lms/templates/discussion/discussion_board_fragment.html
+++ b/lms/templates/discussion/discussion_board_fragment.html
@@ -64,15 +64,3 @@ from openedx.core.djangolib.markup import HTML
 
 <%include file="_underscore_templates.html" />
 <%include file="_thread_list_template.html" />
-
-<%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
-
-  var fbeLink = $("#FBE_banner");
-
-  TrackECommerceEvents.trackUpsellClick(fbeLink, 'discussion_audit_access_expires', {
-      pageName: "discussion_tab",
-      linkType: "link",
-      linkCategory: "FBE_banner"
-  });
-
-</%static:require_module_async>


### PR DESCRIPTION
We are not using track_ecommerce_events module, and this does not exist in `edx-platform`. 
Removing the reference to avoid 404 error on the module.