### PR TITLE
remove code hiding options in discussions

### DIFF
--- a/lms/static/sass/courseware/_appsembler-discussion-overrides.scss
+++ b/lms/static/sass/courseware/_appsembler-discussion-overrides.scss
@@ -494,13 +494,6 @@
   color: $brand-primary-color;
 }
 
-.discussion .actions-dropdown .action-list-item {
-
-  &.action-pin, &.action-close {
-    display: none;
-  }
-}
-
 .discussion .actions-dropdown .action-list-item:hover, .discussion .actions-dropdown .action-list-item:focus {
   color: $brand-primary-color;
 }


### PR DESCRIPTION
This removes the code that we added to hide moderating options in Discussions because they didn't work.