### PR TITLE
Fix some discussion actions bugs

### DIFF
--- a/lms/static/sass/courseware/_appsembler-discussion-overrides.scss
+++ b/lms/static/sass/courseware/_appsembler-discussion-overrides.scss
@@ -541,3 +541,11 @@
 .content-wrapper .discussion.page-content-container .page-content .discussion-body .forum-content .discussion-article .post-extended-content .discussion-response .response-header .response-header-actions .actions-item .actions-dropdown .actions-dropdown-list button.action-list-item {
   border: none;
 }
+
+.edit-post-body .wmd-panel, .discussion-response .response-body, .discussion-post .post-body {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  -ms-word-break: break-all;
+  word-break: break-all;
+  word-break: break-word;
+}


### PR DESCRIPTION
A few fixes for discussions:

- random pink elements now properly coloured
- action buttons for posts are now hidden and shown as they should
- fix width of input on post editing
- fix overflowing of discussion post width in case of long urls (https://appsembler.atlassian.net/browse/RED-2271)