### PR TITLE
fix broken tracking script imports

### DIFF
--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -291,36 +291,3 @@ ${HTML(fragment.foot_html())}
       % endif
     </nav>
 % endif
-
-<%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
-
-  var fbeLink = $("#FBE_banner");
-  var welcomeLink = $("#welcome");
-  var accessDeniedUpsellLink = $("#accessDeniedUpsell");
-  var sockLink = $("#sock");
-
-  TrackECommerceEvents.trackUpsellClick(fbeLink, 'in_course_audit_access_expires', {
-      pageName: "in_course",
-      linkType: "link",
-      linkCategory: "FBE_banner"
-  });
-
-  TrackECommerceEvents.trackUpsellClick(welcomeLink, 'in_course_welcome', {
-      pageName: "in_course",
-      linkType: "link",
-      linkCategory: "welcome"
-  });
-
-  TrackECommerceEvents.trackUpsellClick(accessDeniedUpsellLink, 'in_course_upgrade', {
-    pageName: "in_course",
-    linkType: "link",
-    linkCategory: "(none)"
-  });
-
-  TrackECommerceEvents.trackUpsellClick(sockLink, 'in_course_sock', {
-      pageName: "in_course",
-      linkType: "button",
-      linkCategory: "green_upgrade"
-  });
-
-</%static:require_module_async>

--- a/lms/templates/discussion/discussion_board_fragment.html
+++ b/lms/templates/discussion/discussion_board_fragment.html
@@ -64,15 +64,3 @@ from openedx.core.djangolib.markup import HTML
 
 <%include file="_underscore_templates.html" />
 <%include file="_thread_list_template.html" />
-
-<%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
-
-  var fbeLink = $("#FBE_banner");
-
-  TrackECommerceEvents.trackUpsellClick(fbeLink, 'discussion_audit_access_expires', {
-      pageName: "discussion_tab",
-      linkType: "link",
-      linkCategory: "FBE_banner"
-  });
-
-</%static:require_module_async>


### PR DESCRIPTION
RED-2314. `js/commerce/track_ecommerce_events` is not available in Juniper. It creates frontend errors. This was copied from Koa.