### PR TITLE
Fix label overflow of graph on progress page

### DIFF
--- a/lms/static/sass/pages/_dashboard.scss
+++ b/lms/static/sass/pages/_dashboard.scss
@@ -369,3 +369,9 @@ div#unenroll-modal {
     border: $cta-button-border;
   }
 }
+
+.profile-wrapper .tickLabel {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
Reported in a bug report here: https://appsembler.atlassian.net/browse/RED-2429

Essentially, labels for longer section names would overflow weirdly. Added some CSS to handle the overflow with ellipsis.