### PR TITLE
Fix modal container width

### DIFF
--- a/lms/static/sass/base/_modals.scss
+++ b/lms/static/sass/base/_modals.scss
@@ -1,4 +1,5 @@
 .a--modal {
+  width: 100%;
   background-color: rgba(darken($brand-primary-color, 40%), 0.65);
 
   &__outer-container {


### PR DESCRIPTION
## Fix the container width for modals

> Nate found a bug where our (video) modals are max 480px width. The issue comes from edx core css code overriding some of our rules. This fixes it.

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [RED-2459](https://appsembler.atlassian.net/browse/RED-2549) 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
