### PR TITLE
Add proper typography styling to course custom pages

### DIFF
--- a/lms/static/sass/courseware/_static-pages.scss
+++ b/lms/static/sass/courseware/_static-pages.scss
@@ -12,4 +12,80 @@ body.view-in-course .content-wrapper {
       padding: calcRem(20);
     }
   }
+
+  .xmodule_display.xmodule_StaticTabBlock {
+
+
+    h1, h2, h3, h4 {
+      text-transform: none;
+      letter-spacing: 0;
+    }
+
+    h1 {
+      @include fontVariantInclude($global-font-h1);
+      font-size: $font-size-h1;
+      line-height: $line-height-h1;
+      margin: $font-size-h1 0;
+    }
+
+    h2 {
+      @include fontVariantInclude($global-font-h2);
+      font-size: $font-size-h2;
+      line-height: $line-height-h2;
+      color: $brand-primary-color;
+      margin: $font-size-h2 0;
+    }
+
+    h3 {
+      @include fontVariantInclude($global-font-h3);
+      font-size: $font-size-h3;
+      line-height: $line-height-h3;
+      color: $brand-primary-color;
+      margin: $font-size-h3 0;
+    }
+
+    h4 {
+      @include fontVariantInclude($global-font-h4);
+      font-size: $font-size-h4;
+      line-height: $line-height-h4;
+      color: $brand-primary-color;
+      margin: $font-size-h4 0;
+    }
+
+    h5 {
+      @include fontVariantInclude($global-font-h4);
+      font-size: $font-size-h4;
+      line-height: $line-height-h4;
+      color: $base-text-color;
+      margin: $font-size-h4 0;
+    }
+
+    h6 {
+      @include fontVariantInclude($global-font-h4);
+      font-size: $font-size-base-body*1.2;
+      line-height: $line-height-base-body*1.2;
+      color: rgba($base-text-color, 0.75);
+      margin: $font-size-h4 0;
+    }
+
+    p {
+      @include fontVariantInclude($global-font-base-body);
+      font-size: $font-size-base-courseware;
+      line-height: $line-height-base-courseware !important;
+
+      @media (max-width: $screen-sm-max) {
+        font-size: calcRem(16);
+      }
+    }
+
+    ul, ol {
+      padding: 0 0 0 calcRem(30);
+    }
+
+    ul li, ol li, .xmodule_display.xmodule_CapaModule div.problem p {
+      @include fontVariantInclude($global-font-base-body);
+      font-size: $font-size-base-courseware;
+      line-height: $line-height-base-body;
+    }
+  }
 }


### PR DESCRIPTION
## Add proper typography styling to course custom pages

> SERP discovered that the same HTML appears differently in custom pages vs regular course content (screenshots below).
When investigating, Matthew found that the core theme is currently using a font size of 1em on custom pages, rather than 1.125rem. This PR fixes this.

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## JIRA issue

> Fix [RED-2569](https://appsembler.atlassian.net/browse/RED-2569) 

## Checklists

### Development

- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [X] Automated tests covering modified code pass

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
