### PR TITLE
Matej/add register parameters js

### DIFF
--- a/lms/static/js/base.js
+++ b/lms/static/js/base.js
@@ -87,29 +87,6 @@ $(document).ready(function(){
 	tag.src = "//www.youtube.com/player_api";
 	var firstScriptTag = document.getElementsByTagName('script')[0];
 	firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
-	console.log('something1')
-	// Load parameters automatically into registration form
-	if ($("#login-and-registration-container").length) {
-
-		console.log('something2')
-
-		const urlParams = new URLSearchParams(window.location.search);
-
-		if (urlParams.get('email') && $("#register-email").length) {
-			$("#register-email").value = urlParams.get('email');
-			$("#register-email").readOnly = true;
-		}
-
-		if (urlParams.get('fullname') && $("#register-name").length) {
-			$("#register-name").value = urlParams.get('fullname');
-			$("#register-name").readOnly = true;
-		}
-
-		if (urlParams.get('username') && $("#register-username").length) {
-			$("#register-username").value = urlParams.get('username');
-			$("#register-username").readOnly = true;
-		}
-	}
 });
 
 

--- a/lms/static/sass/pages/_combined-login-register.scss
+++ b/lms/static/sass/pages/_combined-login-register.scss
@@ -141,6 +141,11 @@
           border-bottom: 2px solid $brand-primary-color;
           box-shadow: 0px 2px 10px 0px rgba(0,0,0,0.2);
         }
+
+        &:disabled {
+          opacity: 0.7;
+          pointer-events: none;
+        }
       }
 
       select.input-inline, select.input-block {

--- a/lms/templates/student_account/login_and_register.html
+++ b/lms/templates/student_account/login_and_register.html
@@ -17,6 +17,7 @@
     </%static:require_module>
 </%block>
 
+
 <%block name="header_extras">
   % if get_global_settings()['enable_registration_form']:
     % for template_name in ["account", "access", "form_field", "register", "institution_login", "institution_register", "password_reset", "hinted_login"]:
@@ -63,3 +64,39 @@
 <div class="section-bkg-wrapper">
     <div id="login-and-registration-container" class="login-register bs-container"></div>
 </div>
+
+
+<script type="text/javascript" defer>
+	// Load parameters automatically into registration form
+  function setFields(urlParams, attempts = 0) {
+    setTimeout(() => {
+      attempts = attempts + 1;
+      let set = false;
+      if (urlParams.get('email') && $("#register-email").length) {
+        $("#register-email").val(urlParams.get('email'));
+        $("#register-email").attr('disabled', 'true');
+        set = true;
+      }
+      if (urlParams.get('fullname') && $("#register-name").length) {
+        $("#register-name").val(urlParams.get('fullname'));
+        $("#register-name").attr('disabled', 'true');
+        set = true;
+      }
+      if (urlParams.get('username') && $("#register-username").length) {
+        $("#register-username").val(urlParams.get('username'));
+        $("#register-username").attr('disabled', 'true');
+        set = true;
+      }
+      if ((attempts < 12) && !set) {
+        setFields(urlParams, attempts);
+      }
+    }, 500)
+  };
+
+  $(document).ready(function(){
+    const urlParams = new URLSearchParams(window.location.search);
+    if ($("#login-and-registration-container").length && (urlParams.get('email') || urlParams.get('fullname') || urlParams.get('username'))) {
+      setFields(urlParams);
+    }
+  })
+</script>


### PR DESCRIPTION
## Change description

If a URL parameter is present on /register, it will auto populate fields. Parameters example:
`https://mysite.com/register?email=bugs@bunny.com&fullname=Whatevs&username=asdf`

Any or none of parameters can be present.

A simple piece of JS in the page will detect if the container div for login/register is there, and then make attempts to set fields once they actually render from edx JS.


![Screenshot 2022-01-19 at 16 59 30](https://user-images.githubusercontent.com/10602234/150168000-37a5a466-71b2-4075-8ca9-93f534ade559.png)



## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
