### PR TITLE
refactor: explicit tahoe-v2 file names

### DIFF
--- a/lms/static/sass/_main-v2.scss
+++ b/lms/static/sass/_main-v2.scss
@@ -23,10 +23,10 @@
 @import "../../../customer_specific/lms/static/sass/base/branding-basics";
 
 // Set defaults in case some variables aren't defined
-@import "../../../customer_specific/lms/static/sass/base/site-config-variables-defaults";
+@import "../../../customer_specific/lms/static/sass/base/tahoe-v2-variables-defaults";
 
 // Assign variables (adapt) to old variable names in the theme
-@import "../../../customer_specific/lms/static/sass/base/site-config-variables-adapter";
+@import "../../../customer_specific/lms/static/sass/base/tahoe-v2-variables-adapter";
 
 // Import typography
 @import "base/typography";


### PR DESCRIPTION
Using `site-config` can be misleading. `tahoe-v2` theme is more explicit and clear.