### PR TITLE
enable new sass version compiling with fallbacks

### DIFF
--- a/lms/static/sass/_main-v2.scss
+++ b/lms/static/sass/_main-v2.scss
@@ -19,14 +19,16 @@
 // Import mixins
 @import "base/mixins";
 
-// Inject variables from site configuration
-@import "../../../customer_specific/lms/static/sass/base/branding-basics";
-
 // Set defaults in case some variables aren't defined
 @import "../../../customer_specific/lms/static/sass/base/tahoe-v2-variables-defaults";
 
+// Load set variables from site config
+@import "../../../customer_specific/lms/static/sass/base/tahoe-v2-variables-overrides";
+
 // Assign variables (adapt) to old variable names in the theme
 @import "../../../customer_specific/lms/static/sass/base/tahoe-v2-variables-adapter";
+
+
 
 // Import typography
 @import "base/typography";


### PR DESCRIPTION
## Change description

SASS compilation still wasn't working properly and I finally figured out why. The code in edx-platform is still trying to replace the `_branding-basics.scss` file and load the variables as they are in old format of `'$varName': [ 'val1', 'val2' ]`.

Therefore a better system is created where we don't depend on Site Configuration having _all_ the variables, but we only care to override with whichever it has. Also this system is less prone to errors in case of wrong var name etc.

There are three PRs here that go hand-in-hand:
- edx-platform - [1162](https://github.com/appsembler/edx-platform/pull/1162)
- edx-theme-codebase - [201](https://github.com/appsembler/edx-theme-codebase/pull/201)
- edx-theme-customers - [198](https://github.com/appsembler/edx-theme-customers/pull/198)

Basically SASS has been done in a way where it will load the following and in exact order:

1. `_tahoe-v2-variables-defaults.scss` - holds the default values for variables and makes sure SASS compiles even when variables are not set.
2. `_tahoe-v2-variables-overrides.scss` - empty by default, gets overridden by the compiler with values from the site configuration.
3. `_tahoe-v2-variables-adapter.scss` - assigns values from new variables into old variables. Allows us to migrate to new variables and naming without messing with _all_ the styles. Replaces the `_branding-basics.scss` file.


## Type of change
- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
