### PR TITLE
fix compiling v1

### DIFF
--- a/lms/static/sass/main.scss
+++ b/lms/static/sass/main.scss
@@ -1,4 +1,4 @@
-
+$selected_font_family: null !default;
 
 // Import Bourbon.io
 @import "bourbon/bourbon";


### PR DESCRIPTION
## Change description

V1 didn't have the default for the new variable `$selected_font_family`. This fixes it.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
